### PR TITLE
removed redundant "to" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Examini is a small debugging tool for examining the machine code ran by a linux process.
 
 ## Features
-Currently Examini allows the user to either start a process as a child or to trace an external process by passing its pid. It then shows a disassembled assembly code in the terminal, this can be done either continuously or step by step.
+Currently Examini allows the user to either start a process as a child or trace an external process by passing its pid. It then shows a disassembled assembly code in the terminal, this can be done either continuously or step by step.
 
 As of now Examini only supports 64-bit machine code.
 


### PR DESCRIPTION
The second appearance of "to" in the sentence only blocks the flow of reading the sentence as it is already covered having used the word "either" after the first "to".